### PR TITLE
Time Division Multiplexing up to 16 source

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -18,9 +18,12 @@ sources:
   - rtl/cic_comb.sv
   - rtl/cic_integrator.sv
   - rtl/i2s_clk_gen.sv
+  - rtl/i2s_rx_dsp_channel.sv
   - rtl/i2s_rx_channel.sv
+  - rtl/i2s_tx_dsp_channel.sv
   - rtl/i2s_tx_channel.sv
   - rtl/i2s_ws_gen.sv
+  - rtl/i2s_dsp_ws_gen.sv
   - rtl/udma_i2s_reg_if.sv
     # Level 1
   - rtl/cic_top.sv

--- a/rtl/i2s_dsp_ws_gen.sv
+++ b/rtl/i2s_dsp_ws_gen.sv
@@ -1,0 +1,133 @@
+module i2s_dsp_ws_gen (
+  input logic sck_i,
+  input logic rstn_i,
+  input logic cfg_ws_en_i,
+  input logic [4:0] cfg_num_bits_i,
+  input logic [3:0] cfg_num_words_i,
+  input logic [15:0] cfg_dsp_setup_time_i,
+  input logic   cfg_dsp_mode_i,
+  output logic ws_o
+);
+
+  logic [15:0] limit;
+  enum {IDLE,WAIT,PULSE,PERIOD} state, state_n, state_p, next_state;
+  /*
+  NB: This is the WS generator for DSP protocol and it has the following op mode
+  cfg_dsp_mode_i  0 : drive SW line on the negedge sck_i --> RX fifo must sample data on posedge
+  cfg_dsp_mode_i  1 : drive SW line on the posedge sck_i --> RX fifo must sample data on negedge
+
+  IDLE: ws_o line not driven
+  WAIT: ws_o line not driven for the setup time of the slave
+  PULSE: ws_o line in high level for 1 sck_i
+  PERIOD: ws_o line in low level for (cfg_num_bits_i * cfg_num_words_i)-1
+*/
+  logic [15:0] count;
+  logic set;
+  logic        sck_inverter;
+
+  pulp_clock_inverter clk_inv_i2s_ws_dsp
+    (
+      .clk_i(sck_i),
+      .clk_o(sck_inverter)
+    );
+
+  assign limit = ((cfg_num_bits_i+1) * (cfg_num_words_i+1)-1);
+  
+  assign state= cfg_dsp_mode_i? state_p: state_n;
+  
+  always_ff@ (posedge sck_inverter, negedge rstn_i)
+    begin
+      if (rstn_i == 1'b0)
+        state_n <= IDLE;
+      else begin
+        if(cfg_dsp_mode_i==1'b0) 
+          state_n <= next_state;      
+      end
+    end
+
+  always_ff@ (posedge sck_i, negedge rstn_i)
+    begin
+      if (rstn_i == 1'b0) begin
+        count <= 'h0;
+        state_p <= IDLE;
+      end else begin
+     
+        if(set==1'b1 || next_state==IDLE)
+          count <= 'h0;
+        else
+          count <= count+1;
+        
+        if(cfg_dsp_mode_i==1'b1)
+          state_p <= next_state; 
+      end
+    end
+
+  always_comb
+    begin
+      set=1'b0;
+      ws_o=1'b0;
+      next_state = IDLE;
+
+      case(state)
+        IDLE:
+          begin
+            
+            if(cfg_ws_en_i==1'b1)
+              begin
+                if(cfg_dsp_setup_time_i!= 'd0) begin
+                  next_state = WAIT;
+                  set=1'b1;
+                end else
+                  next_state = PULSE;
+              end
+            
+          end
+
+        WAIT:
+          begin
+            
+            if(cfg_ws_en_i==1'b1)
+              begin
+                if(count<cfg_dsp_setup_time_i)
+                  next_state = WAIT;
+                else
+                  begin
+                    next_state = PULSE;
+                  end
+              end
+            
+          end
+
+        PULSE:
+          begin
+            if(cfg_ws_en_i==1'b1)
+              begin
+                next_state = PERIOD;
+                ws_o=1'b1;
+                set=1'b1;
+              end
+            
+          end
+
+        PERIOD:
+          begin
+            
+            if(cfg_ws_en_i==1'b1)
+              begin
+                if (cfg_dsp_mode_i==1'b0 ) begin
+                  if(count<limit)
+                    next_state = PERIOD;
+                  else
+                    next_state = PULSE;
+                end else begin
+                  if(count<limit-1)
+                    next_state = PERIOD;
+                  else
+                    next_state = PULSE;
+                end
+              end 
+          end
+
+      endcase
+    end
+endmodule

--- a/rtl/i2s_rx_channel.sv
+++ b/rtl/i2s_rx_channel.sv
@@ -39,7 +39,7 @@ module i2s_rx_channel (
     input  logic                    cfg_en_i, 
     input  logic                    cfg_2ch_i, 
     input  logic              [4:0] cfg_wlen_i, 
-    input  logic              [2:0] cfg_wnum_i, 
+    input  logic              [3:0] cfg_wnum_i, 
     input  logic                    cfg_lsb_first_i
 );
 

--- a/rtl/i2s_rx_dsp_channel.sv
+++ b/rtl/i2s_rx_dsp_channel.sv
@@ -1,0 +1,399 @@
+
+
+module i2s_rx_dsp_channel (
+	input  logic                    sck_i,
+	input  logic                    rstn_i,
+	input  logic                    i2s_ch0_i,
+	input  logic                    i2s_ch1_i,
+	input  logic                    i2s_ws_i,
+	output logic             [31:0] fifo_data_o,
+	output logic                    fifo_data_valid_o,
+	input  logic                    fifo_data_ready_i,
+	output logic                    fifo_err_o,
+	input  logic                    cfg_en_i,
+	input  logic                    cfg_2ch_i,
+	input  logic              [4:0] cfg_num_bits_i,
+	input  logic              [3:0] cfg_num_word_i,
+	input  logic                    cfg_lsb_first_i,
+	input  logic                    cfg_rx_continuous_i,
+	input  logic                    cfg_slave_dsp_mode_i,
+	input  logic              [8:0] cfg_slave_dsp_offset_i
+);
+
+	logic [31:0] r_shiftreg_ch0, s_shiftreg_ch0;
+	logic [31:0] r_shiftreg_ch1, s_shiftreg_ch1;
+
+	logic [31:0] r_shiftreg_ch0_shadow, s_shiftreg_ch0_shadow;
+	logic [31:0] r_shiftreg_ch1_shadow, s_shiftreg_ch1_shadow;
+
+	logic [8:0]  r_count_offset, s_count_offset;
+
+	logic [4:0]  r_count_bit, s_count_bit;
+	logic [4:0]  r_count_word, s_count_word;
+
+	logic        start;
+
+	logic        set_counter;
+
+	logic        r_ch0_valid, s_ch0_valid;
+	logic        r_ch1_valid, s_ch1_valid;
+
+	logic        sck_inverter, sck_r, sck_off;
+
+	enum {IDLE,OFFSET,RUN} state, state_off, state_r, next_state;
+
+	assign fifo_data_o = r_ch0_valid ? r_shiftreg_ch0_shadow : (r_ch1_valid ? r_shiftreg_ch1_shadow : 'h0);
+
+	assign fifo_data_valid_o = (next_state==IDLE | fifo_data_ready_i==1'b0 | (cfg_rx_continuous_i==1'b0 & r_count_word==(cfg_num_word_i+2))) ?  'h0: r_ch0_valid | r_ch1_valid;
+
+	assign state = (state_off==OFFSET)? state_off : state_r;
+
+	pulp_clock_inverter clk_inv_i2s_rx_dsp
+    (
+      .clk_i(sck_i),
+      .clk_o(sck_inverter)
+    );
+
+    pulp_clock_mux2 clk_mux_i2s_rx_dsp
+    (
+      .clk0_i(sck_i),
+      .clk1_i(sck_inverter),
+      .clk_sel_i(cfg_slave_dsp_mode_i),
+      .clk_o(sck_r)
+    );
+
+	pulp_clock_mux2 clk_mux_offset_i2s_rx_dsp
+    (
+      .clk0_i(sck_i),
+      .clk1_i(sck_inverter),
+      .clk_sel_i(~cfg_slave_dsp_mode_i),
+      .clk_o(sck_off)
+    );
+	
+	always_comb
+		begin
+			s_shiftreg_ch0  =  r_shiftreg_ch0;
+			s_shiftreg_ch1  =  r_shiftreg_ch1;
+
+			if (next_state== IDLE) begin
+				s_shiftreg_ch0  =  'h0;
+				s_shiftreg_ch1  =  'h0;
+			end
+
+			if (next_state== RUN) begin
+				if (start == 1'b1 | set_counter==1'b1 ) begin
+
+					if (cfg_lsb_first_i==1'b0) begin
+						if (cfg_2ch_i==1'b1)
+							s_shiftreg_ch1 [31:0] = {31'b0,i2s_ch1_i};
+
+						s_shiftreg_ch0 [31:0] = {31'b0,i2s_ch0_i};
+
+					end else begin
+
+						if (cfg_2ch_i==1'b1)
+							s_shiftreg_ch1 [31:0] = {i2s_ch1_i,31'b0};
+
+						s_shiftreg_ch0 [31:0] = {i2s_ch0_i,31'b0};
+
+					end
+				end else begin
+					if (cfg_lsb_first_i==1'b0) begin
+
+						//Here i'm reading the middle MSB bit
+						if (cfg_2ch_i==1'b1)
+							s_shiftreg_ch1 [31:0] = {r_shiftreg_ch1[30:0],i2s_ch1_i};
+
+						s_shiftreg_ch0 [31:0] = {r_shiftreg_ch0[30:0],i2s_ch0_i};
+
+					end else begin
+
+						//Here i'm reading the middle LSB bit
+						if (cfg_2ch_i==1'b1)
+							s_shiftreg_ch1 [31:0] = {i2s_ch1_i,r_shiftreg_ch1[31:1]};
+
+						s_shiftreg_ch0 [31:0] = {i2s_ch0_i,r_shiftreg_ch0[31:1]};
+					end
+
+				end
+			end
+		end
+
+
+	always_ff  @(posedge sck_r, negedge rstn_i)
+		begin
+			if (rstn_i == 1'b0 ) begin
+
+				r_shiftreg_ch0 <=  'h0;
+				r_shiftreg_ch1 <=  'h0;
+
+			end else begin
+				r_shiftreg_ch0 <=  s_shiftreg_ch0;
+				r_shiftreg_ch1 <=  s_shiftreg_ch1;
+
+			end
+		end
+
+	always_comb
+		begin
+			s_shiftreg_ch0_shadow = r_shiftreg_ch0_shadow;
+			s_shiftreg_ch1_shadow = r_shiftreg_ch1_shadow;
+
+			s_ch0_valid = r_ch0_valid;
+			s_ch1_valid = r_ch1_valid;
+
+			if (next_state== IDLE) begin
+				s_shiftreg_ch0_shadow = 'h0;
+				s_shiftreg_ch1_shadow = 'h0;
+				s_ch0_valid = 1'b0;
+				s_ch1_valid =1'b0;
+			end
+
+			if (next_state== RUN) begin
+				if (r_count_bit+1 == cfg_num_bits_i) begin
+					if (cfg_lsb_first_i==1'b0) begin
+						s_shiftreg_ch0_shadow [31:0] = {r_shiftreg_ch0[30:0],i2s_ch0_i};
+						s_ch0_valid = 1'b1;
+
+						if (cfg_2ch_i==1'b1) begin
+							s_shiftreg_ch1_shadow [31:0] = {r_shiftreg_ch1[30:0],i2s_ch1_i};
+							s_ch1_valid =1'b1;
+						end
+					end else begin
+
+						case (cfg_num_bits_i)
+
+							5'd7:
+								begin
+									s_shiftreg_ch0_shadow [31:0] = {24'b0,i2s_ch0_i,r_shiftreg_ch0[31:25]};
+									s_ch0_valid =1'b1;
+
+									if (cfg_2ch_i==1'b1) begin
+										s_shiftreg_ch1_shadow [31:0] = {24'b0,i2s_ch1_i,r_shiftreg_ch1[31:25]};
+										s_ch1_valid = 1'b1;
+									end
+								end
+
+							5'd15:
+								begin
+									s_shiftreg_ch0_shadow [31:0] = {16'b0,i2s_ch0_i,r_shiftreg_ch0[31:17]};
+									s_ch0_valid = 1'b1;
+
+									if (cfg_2ch_i==1'b1) begin
+										s_shiftreg_ch1_shadow [31:0] = {16'b0,i2s_ch1_i,r_shiftreg_ch1[31:17]};
+										s_ch1_valid =1'b1;
+									end
+								end
+
+							5'd23:
+								begin
+									s_shiftreg_ch0_shadow [31:0] = {8'b0,i2s_ch0_i,r_shiftreg_ch0[31:9]};
+									s_ch0_valid =1'b1;
+
+									if (cfg_2ch_i==1'b1) begin
+										s_shiftreg_ch1_shadow [31:0] = {8'b0,i2s_ch1_i,r_shiftreg_ch1[31:9]};
+										s_ch1_valid = 1'b1;
+									end
+								end
+
+							5'd31:
+								begin
+									s_shiftreg_ch0_shadow [31:0] = {i2s_ch0_i,r_shiftreg_ch0[31:1]};
+									s_ch0_valid = 1'b1;
+
+									if (cfg_2ch_i==1'b1) begin
+										s_shiftreg_ch1_shadow [31:0] = {i2s_ch1_i,r_shiftreg_ch1[31:1]};
+										s_ch1_valid = 1'b1;
+									end
+								end
+
+							default:
+								begin
+
+								end
+
+						endcase
+
+					end
+				end
+			end
+		end
+
+	always_ff  @(posedge sck_r, negedge rstn_i)
+		begin
+			if (rstn_i == 1'b0 ) begin
+
+				r_shiftreg_ch0_shadow <=  'h0;
+				r_shiftreg_ch1_shadow <=  'h0;
+
+				r_ch0_valid <=1'b0;
+				r_ch1_valid <=1'b0;
+
+			end else begin
+				r_shiftreg_ch0_shadow <=  s_shiftreg_ch0_shadow;
+				r_shiftreg_ch1_shadow <=  s_shiftreg_ch1_shadow;
+
+				r_ch0_valid <= s_ch0_valid;
+				r_ch1_valid <= s_ch1_valid;
+
+				if( fifo_data_ready_i == 1'b1) begin
+					if(r_ch0_valid==1'b1)
+						r_ch0_valid <=1'b0;
+					else begin
+						if(cfg_2ch_i==1'b1 & r_ch1_valid==1'b1)
+							r_ch1_valid <=1'b0;
+					end
+				end
+			end
+		end
+
+	always_comb
+		begin
+			s_count_bit = r_count_bit;
+			s_count_offset = r_count_offset;
+			s_count_word = r_count_word;
+
+			if (next_state== IDLE) begin
+				s_count_bit = 'h0;
+				s_count_offset ='h0;
+				s_count_word = 'h0;
+			end
+
+			if (next_state == OFFSET) begin
+				//change polarity
+				s_count_offset = r_count_offset+1;
+			end
+
+			if (next_state== RUN) begin
+				if (start == 1'b1 | set_counter==1'b1 )
+					s_count_bit ='h0;
+				else
+					s_count_bit = r_count_bit+1;
+
+				if (cfg_rx_continuous_i==1'b0 & r_count_bit+1 == cfg_num_bits_i & r_count_word<=cfg_num_word_i+1) begin
+					if(cfg_2ch_i==1'b1)
+						s_count_word = r_count_word+2;
+					else
+						s_count_word = r_count_word+1;
+				end
+				
+			end
+		end
+
+	always_ff  @(posedge sck_r, negedge rstn_i)
+		begin
+			if (rstn_i == 1'b0 ) begin
+				r_count_word <='h0;
+				r_count_bit<='h0;
+			end else begin
+
+				r_count_word <= s_count_word;
+				r_count_bit<= s_count_bit;				
+			end
+		end
+
+	always_comb
+		begin
+
+			next_state= IDLE;
+			start=1'b0;
+			set_counter=1'b0;
+			
+			case(state)
+				IDLE:
+					begin
+						
+						if(cfg_en_i==1'b0) begin
+							next_state= IDLE;
+							start=1'b0;
+							set_counter=1'b0;
+						end
+						else begin
+							if(i2s_ws_i==1'b1 & cfg_slave_dsp_offset_i==9'd0) begin
+								// offset 0
+								next_state=RUN;
+								start=1'b1;
+							end else begin
+								if(i2s_ws_i==1'b1 & cfg_slave_dsp_offset_i!=9'd0) begin
+									next_state=OFFSET;
+									start=1'b0;
+								end else
+									next_state= IDLE;
+							end
+						end
+					end
+
+
+				OFFSET:
+					begin
+						if(cfg_en_i==1'b0) begin
+							next_state= IDLE;
+							start=1'b0;
+							set_counter=1'b0;
+						end else begin
+							if(r_count_offset==cfg_slave_dsp_offset_i) begin
+								next_state=RUN;
+								start=1'b1;
+							end else begin
+								next_state=OFFSET;
+								start=1'b0;
+							end
+						end
+					end
+
+
+				RUN:
+					begin
+
+						start=1'b0;
+
+						if(cfg_en_i==1'b0) begin
+							next_state= IDLE;
+							start=1'b0;
+							set_counter=1'b0;
+						end else begin
+							next_state= RUN;
+
+							if( r_count_bit == cfg_num_bits_i)
+								set_counter=1'b1;
+							else
+								set_counter=1'b0;
+						end
+					end
+
+				default:
+					begin
+						next_state= IDLE;
+						start=1'b0;
+						set_counter=1'b0;
+					end
+
+			endcase
+		end
+
+		always_ff  @(posedge sck_r, negedge rstn_i)
+		begin
+			if (rstn_i == 1'b0 ) begin
+				state_r <=  IDLE;
+			end else 			
+				if (next_state!=OFFSET)
+					state_r<=next_state;			
+		end
+
+		always_ff  @(posedge sck_off, negedge rstn_i)
+		begin
+			if (rstn_i == 1'b0 ) begin
+				r_count_offset<= 'h0;
+				state_off <=  IDLE;
+			end else 			
+				if (next_state==OFFSET) begin
+					state_off<=next_state;
+					r_count_offset<= s_count_offset;
+				end	else begin
+					r_count_offset<= 'h0;
+					state_off <=  IDLE;	
+				end
+		end
+
+endmodule
+

--- a/rtl/i2s_tx_channel.sv
+++ b/rtl/i2s_tx_channel.sv
@@ -35,7 +35,7 @@ module i2s_tx_channel (
     input  logic                    cfg_en_i, 
     input  logic                    cfg_2ch_i, 
     input  logic              [4:0] cfg_wlen_i, 
-    input  logic              [2:0] cfg_wnum_i, 
+    input  logic              [3:0] cfg_wnum_i, 
     input  logic                    cfg_lsb_first_i
 );
 
@@ -57,7 +57,7 @@ module i2s_tx_channel (
     logic        s_update_cnt;
 
     logic [4:0]  r_count_bit;
-    logic [2:0]  r_count_word;
+    logic [3:0]  r_count_word;
 
     logic        s_word_done;
 

--- a/rtl/i2s_tx_dsp_channel.sv
+++ b/rtl/i2s_tx_dsp_channel.sv
@@ -1,0 +1,356 @@
+
+module i2s_tx_dsp_channel (
+  input  logic                    sck_i,
+  input  logic                    rstn_i,
+  output logic                    i2s_ch0_o,
+  output logic                    i2s_ch1_o,
+  input  logic                    i2s_ws_i,
+  input  logic             [31:0] fifo_data_i,
+  input  logic                    fifo_data_valid_i,
+  output logic                    fifo_data_ready_o,
+  output logic                    master_ready_to_send,
+  output logic                    fifo_err_o,
+  input  logic                    cfg_en_i,
+  input  logic                    cfg_2ch_i,
+  input  logic              [4:0] cfg_num_bits_i,
+  input  logic              [3:0] cfg_num_word_i,
+  input  logic                    cfg_lsb_first_i,
+  input  logic                    cfg_master_dsp_mode_i,
+  input  logic              [8:0] cfg_master_dsp_offset_i
+);
+
+
+  logic [31:0] r_shiftreg_ch0;
+  logic [31:0] r_shiftreg_ch1;
+  logic [31:0] s_shiftreg_ch0;
+  logic [31:0] s_shiftreg_ch1;
+  logic [31:0] r_shiftreg_shadow;
+  logic [31:0] s_shiftreg_shadow;
+  logic [31:0] r_shiftreg_shadow1;
+  logic [31:0] s_shiftreg_shadow1;
+
+  logic        s_data_ready;
+  
+  logic        set_offset;
+
+  logic        s_en_offset, r_en_offset;
+  logic        r_clear_offset, s_clear_offset;
+
+  logic        check_offset;
+
+
+  logic [4:0]  r_count_bit, s_count_bit;
+  logic [8:0]  r_count_offset, s_count_offset;
+
+  logic        s_word_done;
+  logic        s_word_done_pre;
+
+
+  logic        sck_inverter, sck_r;
+
+  enum  {START,SAMPLE,WAIT,RUN} state, next_state;
+
+  assign s_word_done     = cfg_lsb_first_i?  r_count_bit == cfg_num_bits_i  : r_count_bit == 'h0;
+  assign s_word_done_pre = cfg_lsb_first_i?  r_count_bit == cfg_num_bits_i-4 : r_count_bit == 'h4;
+
+  assign fifo_data_ready_o = s_data_ready;
+
+  assign set_offset = (cfg_master_dsp_offset_i!='h0 )? 1'b1 : 1'b0;
+  assign check_offset = set_offset ^ r_clear_offset;
+
+
+  pulp_clock_inverter clk_inv_i2s_tx_dsp
+    (
+      .clk_i(sck_i),
+      .clk_o(sck_inverter)
+    );
+
+  pulp_clock_mux2 clk_mux_i2s_tx_dsp
+    (
+      .clk0_i(sck_inverter),
+      .clk1_i(sck_i),
+      .clk_sel_i(cfg_master_dsp_mode_i),
+      .clk_o(sck_r)
+    );
+
+  always_comb begin : proc_SM
+
+    s_shiftreg_ch0    = r_shiftreg_ch0;
+    s_shiftreg_ch1    = r_shiftreg_ch1;
+    s_shiftreg_shadow = r_shiftreg_shadow;
+    s_shiftreg_shadow1 = r_shiftreg_shadow1;
+
+    s_data_ready = 1'b0;
+
+    next_state = START;
+
+    case(state)
+
+      START:
+        begin
+          
+          if(cfg_en_i==1'b0) begin
+            next_state= START;
+            s_shiftreg_ch0    = 'h0;
+            s_shiftreg_ch1    = 'h0;
+            s_shiftreg_shadow = 'h0;
+            s_shiftreg_shadow1 = 'h0;
+          end else begin
+            if(fifo_data_valid_i == 1'b1)
+              begin
+                s_data_ready    = 1'b1;
+                s_shiftreg_ch0 = fifo_data_i;
+                next_state = SAMPLE;
+              end else
+                next_state = START;
+          end
+        end
+
+      SAMPLE:
+        begin
+
+          if(cfg_en_i==1'b0) begin
+            next_state= START;
+            s_shiftreg_ch0    = 'h0;
+            s_shiftreg_ch1    = 'h0;
+            s_shiftreg_shadow = 'h0;
+            s_shiftreg_shadow1 = 'h0;
+          end else begin
+            if(fifo_data_valid_i== 1'b1)
+              begin
+                s_data_ready    = 1'b1;
+                s_shiftreg_ch1 = fifo_data_i;
+                next_state = WAIT;
+              end else
+                next_state = SAMPLE;
+          end
+        end
+
+      WAIT:
+        begin
+
+          if(cfg_en_i==1'b0) begin
+            next_state= START;
+            s_shiftreg_ch0    = 'h0;
+            s_shiftreg_ch1    = 'h0;
+            s_shiftreg_shadow = 'h0;
+            s_shiftreg_shadow1 = 'h0;
+          end else begin
+
+            if(i2s_ws_i== 1'b1)
+              next_state = RUN;
+            else
+              next_state = WAIT;
+            
+          end
+        end
+
+      RUN:
+        begin
+        
+          if(cfg_en_i==1'b0) begin
+
+            next_state= START;
+            s_shiftreg_ch0    = 'h0;
+            s_shiftreg_ch1    = 'h0;
+            s_shiftreg_shadow = 'h0;
+            s_shiftreg_shadow1 = 'h0;
+
+          end else begin
+
+            next_state= RUN;
+
+            if(check_offset==1'b0)  begin
+
+              if(s_word_done_pre== 1'b1)begin
+                
+                if(cfg_2ch_i== 1'b1) begin
+                  s_data_ready    = 1'b1;
+
+                  if(fifo_data_valid_i == 1'b1)
+                    s_shiftreg_shadow = fifo_data_i;
+                
+                end 
+              
+              end else begin
+
+                if(s_word_done== 1'b1)begin
+                  
+                  s_data_ready = 1'b1;
+                  
+                  if(cfg_2ch_i== 1'b1) begin
+                    s_shiftreg_ch0 = r_shiftreg_shadow;
+                    
+                    if(fifo_data_valid_i == 1'b1)
+                      s_shiftreg_ch1 = fifo_data_i;
+
+                  end else begin
+                    s_shiftreg_ch0 = r_shiftreg_ch1;
+
+                    if (cfg_master_dsp_mode_i==1'b1) begin
+                      if(fifo_data_valid_i == 1'b1)
+                        s_shiftreg_ch1 = fifo_data_i;
+                    end
+                  end
+
+                end else begin
+
+                  if (cfg_master_dsp_mode_i==1'b0) begin               
+                    if(fifo_data_valid_i == 1'b1) begin
+                      if(cfg_2ch_i== 1'b0)
+                        s_shiftreg_ch1 = fifo_data_i;
+                      else
+                        s_shiftreg_shadow = fifo_data_i;
+                    end
+                  end 
+
+                end
+
+
+              end
+
+            end //close check_offset
+
+          end//close else enable
+        end
+
+    endcase // state
+  end
+
+  always_ff  @(posedge sck_r, negedge rstn_i)
+    begin
+      if (rstn_i == 1'b0 ) begin
+        state <= START;
+        master_ready_to_send <= 1'b0;
+      end else begin
+        if (next_state==START)
+          master_ready_to_send <= 1'b0;
+        else
+          if (next_state==WAIT)
+            master_ready_to_send <= 1'b1;
+          else
+            master_ready_to_send <= master_ready_to_send;
+
+        state <= next_state;
+
+      end
+    end
+
+  always_ff  @(posedge sck_r, negedge rstn_i)
+    begin
+      if (rstn_i == 1'b0)
+        begin
+          r_shiftreg_ch0  <=  'h0;
+          r_shiftreg_ch1  <=  'h0;
+          r_shiftreg_shadow <= 'h0;
+          r_shiftreg_shadow1 <= 'h0;
+        end
+      else
+        begin   
+          r_shiftreg_ch0  <= s_shiftreg_ch0;         
+          r_shiftreg_ch1  <= s_shiftreg_ch1;         
+          r_shiftreg_shadow  <= s_shiftreg_shadow;
+          r_shiftreg_shadow1  <= s_shiftreg_shadow1;
+        end
+    end
+
+  always_comb
+    begin
+
+      s_count_bit = r_count_bit;
+      s_count_offset = r_count_offset;
+      s_en_offset = r_en_offset;
+      s_clear_offset = r_clear_offset;
+
+      i2s_ch0_o = 1'b0;
+      i2s_ch1_o = 1'b0;
+
+      if (next_state== START) begin
+
+        s_count_bit = 'h0;
+        s_count_offset = 'h0;
+
+        s_en_offset = 1'b0;
+        s_clear_offset  = 1'b0;
+
+        i2s_ch0_o = 1'b0;
+        i2s_ch1_o = 1'b0;
+
+      end else begin
+
+        i2s_ch0_o = r_shiftreg_ch0[r_count_bit];
+        
+        if (cfg_2ch_i==1'b1)
+          i2s_ch1_o = r_shiftreg_ch1[r_count_bit];
+
+        if((next_state== RUN & i2s_ws_i== 1'b1 & cfg_master_dsp_offset_i!=9'b0 & check_offset==1'b1) | r_en_offset==1'b1) begin
+
+          if (r_count_offset+1==cfg_master_dsp_offset_i) begin
+            s_clear_offset = 1'b1;
+            s_en_offset = 1'b0;
+
+            if (cfg_lsb_first_i==1'b0)
+              s_count_bit = cfg_num_bits_i;
+            else
+              s_count_bit = 1'b0;
+
+          end else begin
+            s_count_offset = r_count_offset + 1;
+            s_en_offset = 1'b1;
+            s_clear_offset = 1'b0;
+          end
+
+        end else begin
+          s_clear_offset = r_clear_offset;
+
+          if (next_state== RUN & i2s_ws_i== 1'b1 | state == RUN) begin
+
+            if (cfg_lsb_first_i==1'b0) begin
+
+              if (r_count_bit=='h0)
+                s_count_bit = cfg_num_bits_i;
+              else
+                s_count_bit = r_count_bit - 1;
+
+            end else begin
+
+              if (r_count_bit==cfg_num_bits_i)
+                s_count_bit = 'h0;
+              else
+                s_count_bit = r_count_bit + 1;
+
+            end
+
+          end else begin
+
+            if (cfg_lsb_first_i==1'b0)
+              s_count_bit = cfg_num_bits_i;
+            else
+              s_count_bit = 'h0;
+
+          end
+        end
+      end
+    end
+
+  always_ff  @(posedge sck_r, negedge rstn_i)
+    begin
+      if (rstn_i == 1'b0 ) begin
+
+        r_count_bit <= 'h0;
+        r_count_offset <= 'h0;
+        r_en_offset <= 'h0;
+        r_clear_offset <= 'h0;
+
+      end else begin
+
+        r_count_bit <= s_count_bit;
+        r_count_offset <= s_count_offset;
+        r_en_offset <= s_en_offset;
+        r_clear_offset <= s_clear_offset;
+
+      end
+    end
+
+endmodule
+

--- a/rtl/i2s_txrx.sv
+++ b/rtl/i2s_txrx.sv
@@ -44,11 +44,26 @@ module i2s_txrx (
 
     input  logic                      cfg_slave_en_i,
     input  logic                      cfg_master_en_i,
+    
+    //DSP reg
+    input  logic                      cfg_slave_dsp_en_i,
+    input  logic               [15:0] cfg_slave_dsp_setup_time_i,
+    input  logic                      cfg_slave_dsp_mode_i,
+    input  logic                [8:0] cfg_slave_dsp_offset_i,
+
+    input  logic                      cfg_master_dsp_en_i,
+    input  logic               [15:0] cfg_master_dsp_setup_time_i,
+    input  logic                      cfg_master_dsp_mode_i,
+    input  logic                [8:0] cfg_master_dsp_offset_i,
+
+    output logic                      master_ready_to_send,
+    
+    input  logic                      cfg_rx_continuous_i,
 
     input  logic                      cfg_slave_i2s_lsb_first_i,
     input  logic                      cfg_slave_i2s_2ch_i,
     input  logic                [4:0] cfg_slave_i2s_bits_word_i,
-    input  logic                [2:0] cfg_slave_i2s_words_i,
+    input  logic                [3:0] cfg_slave_i2s_words_i,
 
     input  logic                      cfg_slave_pdm_en_i,
     input  logic                [1:0] cfg_slave_pdm_mode_i,
@@ -58,7 +73,7 @@ module i2s_txrx (
     input  logic                      cfg_master_i2s_lsb_first_i,
     input  logic                      cfg_master_i2s_2ch_i,
     input  logic                [4:0] cfg_master_i2s_bits_word_i,
-    input  logic                [2:0] cfg_master_i2s_words_i,
+    input  logic                [3:0] cfg_master_i2s_words_i,
 
     output logic               [31:0] fifo_rx_data_o,
     output logic                      fifo_rx_data_valid_o,
@@ -76,17 +91,59 @@ module i2s_txrx (
     logic        s_pdm_fifo_data_ready;
 
     logic [31:0] s_i2s_slv_fifo_data;
+    logic [31:0] s_i2s_slv_dsp_fifo_data;
     logic        s_i2s_slv_fifo_data_valid;
+    logic        s_i2s_slv_dsp_fifo_data_valid;
     logic        s_i2s_slv_fifo_data_ready;
+    logic        s_i2s_slv_dsp_fifo_data_ready;
 
     logic        s_i2s_slv_en;
+    logic        s_i2s_slv_dsp_en;
 
-    assign s_i2s_slv_en = cfg_slave_en_i & !cfg_slave_pdm_en_i;
+    logic        s_i2s_mst_en;
+    logic        s_i2s_mst_dsp_en;
 
-    assign fifo_rx_data_o            = cfg_slave_pdm_en_i ? {16'h0,s_pdm_fifo_data} : s_i2s_slv_fifo_data;
-    assign fifo_rx_data_valid_o      = cfg_slave_pdm_en_i ? s_pdm_fifo_data_valid   : s_i2s_slv_fifo_data_valid;
-    assign s_i2s_slv_fifo_data_ready = fifo_rx_data_ready_i;
-    assign s_pdm_fifo_data_ready     = fifo_rx_data_ready_i;
+    logic        dsp_pad_master_sd0_o;
+    logic        dsp_pad_master_sd1_o;
+
+    logic        tx_pad_master_sd0_o;
+    logic        tx_pad_master_sd1_o;
+    
+    logic        s_fifo_tx_data_ready_dsp_o;
+    logic        s_fifo_tx_data_ready_o;
+    logic        s_slave_ws_dsp_i;
+    logic        s_master_ws_dsp_i;
+
+    logic        s_slave_ws_i;
+    logic        s_master_ws_i;
+    
+    assign s_i2s_slv_en = cfg_slave_en_i & ~cfg_slave_pdm_en_i & ~cfg_slave_dsp_en_i;
+    assign s_i2s_slv_dsp_en = cfg_slave_en_i & cfg_slave_dsp_en_i;
+
+    assign s_i2s_mst_en = cfg_master_en_i & ~cfg_master_dsp_en_i;
+    assign s_i2s_mst_dsp_en = cfg_master_en_i & cfg_master_dsp_en_i;
+
+    assign s_slave_ws_dsp_i = s_i2s_slv_dsp_en ? slave_ws_i : 'h0;
+    assign s_master_ws_dsp_i = s_i2s_mst_dsp_en ? master_ws_i : 'h0;
+
+    assign s_slave_ws_i = s_i2s_slv_en ?  slave_ws_i : 'h0;
+    assign s_master_ws_i = s_i2s_mst_en ? master_ws_i : 'h0;
+
+    assign pad_master_sd0_o =  s_i2s_mst_dsp_en? dsp_pad_master_sd0_o : tx_pad_master_sd0_o;
+    assign pad_master_sd1_o =  s_i2s_mst_dsp_en? dsp_pad_master_sd1_o : tx_pad_master_sd1_o;
+
+    assign fifo_tx_data_ready_o =  s_i2s_mst_dsp_en? s_fifo_tx_data_ready_dsp_o : s_i2s_mst_en ? s_fifo_tx_data_ready_o : 'h0;
+    
+
+    assign fifo_rx_data_o            = cfg_slave_pdm_en_i ? {16'h0,s_pdm_fifo_data} : s_i2s_slv_dsp_en ? s_i2s_slv_dsp_fifo_data : s_i2s_slv_en? s_i2s_slv_fifo_data:'h0;
+    assign fifo_rx_data_valid_o      = cfg_slave_pdm_en_i ? s_pdm_fifo_data_valid   : s_i2s_slv_dsp_en ? s_i2s_slv_dsp_fifo_data_valid : s_i2s_slv_en? s_i2s_slv_fifo_data_valid: 'h0;
+    
+
+    assign s_i2s_slv_fifo_data_ready = s_i2s_slv_en ? fifo_rx_data_ready_i : 'h0;
+    assign s_pdm_fifo_data_ready     = cfg_slave_pdm_en_i ? fifo_rx_data_ready_i : 'h0;
+    assign s_i2s_slv_dsp_fifo_data_ready = s_i2s_slv_dsp_en ? fifo_rx_data_ready_i : 'h0;
+
+
 
     i2s_rx_channel i_i2s_slave 
     (
@@ -95,7 +152,7 @@ module i2s_txrx (
 
         .i2s_ch0_i         ( pad_slave_sd0_i           ),
         .i2s_ch1_i         ( pad_slave_sd1_i           ),
-        .i2s_ws_i          ( slave_ws_i                ),
+        .i2s_ws_i          ( s_slave_ws_i                ),
 
         .fifo_data_o       ( s_i2s_slv_fifo_data       ),
         .fifo_data_valid_o ( s_i2s_slv_fifo_data_valid ),
@@ -108,6 +165,57 @@ module i2s_txrx (
         .cfg_wlen_i        ( cfg_slave_i2s_bits_word_i ),
         .cfg_wnum_i        ( cfg_slave_i2s_words_i     ),
         .cfg_lsb_first_i   ( cfg_slave_i2s_lsb_first_i )
+    );
+    
+    //DSP rx channel
+    i2s_rx_dsp_channel i_i2s_dsp_slave 
+    (
+        .sck_i             ( slave_clk_i               ),
+        .rstn_i            ( rstn_i                    ),
+
+        .i2s_ch0_i         ( pad_slave_sd0_i           ),
+        .i2s_ch1_i         ( pad_slave_sd1_i           ),
+        .i2s_ws_i          ( s_slave_ws_dsp_i                ),
+
+        .fifo_data_o       ( s_i2s_slv_dsp_fifo_data       ),
+        .fifo_data_valid_o ( s_i2s_slv_dsp_fifo_data_valid ),
+        .fifo_data_ready_i ( s_i2s_slv_dsp_fifo_data_ready ),
+
+        .fifo_err_o        (                           ),
+        
+        .cfg_en_i                  ( s_i2s_slv_dsp_en          ),
+        .cfg_2ch_i                 ( cfg_slave_i2s_2ch_i       ),
+        .cfg_num_bits_i            ( cfg_slave_i2s_bits_word_i ),
+        .cfg_num_word_i            ( cfg_slave_i2s_words_i     ),
+        .cfg_lsb_first_i           ( cfg_slave_i2s_lsb_first_i ),
+        .cfg_rx_continuous_i       ( cfg_rx_continuous_i       ),
+        .cfg_slave_dsp_mode_i      ( cfg_slave_dsp_mode_i      ),
+        .cfg_slave_dsp_offset_i    ( cfg_slave_dsp_offset_i    )
+    );
+
+    i2s_tx_dsp_channel i_i2s_dsp_master 
+    (
+        .sck_i             ( master_clk_i               ),
+        .rstn_i            ( rstn_i                     ),
+
+        .i2s_ch0_o         ( dsp_pad_master_sd0_o           ),
+        .i2s_ch1_o         ( dsp_pad_master_sd1_o           ),
+        .i2s_ws_i          ( s_master_ws_dsp_i                ),
+
+        .fifo_data_i       ( fifo_tx_data_i             ),
+        .fifo_data_valid_i ( fifo_tx_data_valid_i       ),
+        .fifo_data_ready_o ( s_fifo_tx_data_ready_dsp_o       ),
+        .master_ready_to_send       ( master_ready_to_send       ),
+
+        .fifo_err_o        (                            ),
+
+        .cfg_en_i          ( s_i2s_mst_dsp_en            ),
+        .cfg_2ch_i         ( cfg_master_i2s_2ch_i       ),
+        .cfg_num_bits_i        ( cfg_master_i2s_bits_word_i ),
+        .cfg_num_word_i        ( cfg_master_i2s_words_i     ),
+        .cfg_lsb_first_i   ( cfg_master_i2s_lsb_first_i ),
+        .cfg_master_dsp_mode_i      ( cfg_master_dsp_mode_i      ),
+        .cfg_master_dsp_offset_i    ( cfg_master_dsp_offset_i    )
     );
 
     pdm_top i_pdm (
@@ -130,17 +238,17 @@ module i2s_txrx (
         .sck_i             ( master_clk_i               ),
         .rstn_i            ( rstn_i                     ),
 
-        .i2s_ch0_o         ( pad_master_sd0_o           ),
-        .i2s_ch1_o         ( pad_master_sd1_o           ),
-        .i2s_ws_i          ( master_ws_i                ),
+        .i2s_ch0_o         ( tx_pad_master_sd0_o       ),
+        .i2s_ch1_o         ( tx_pad_master_sd1_o           ),
+        .i2s_ws_i          ( s_master_ws_i                ),
 
         .fifo_data_i       ( fifo_tx_data_i             ),
         .fifo_data_valid_i ( fifo_tx_data_valid_i       ),
-        .fifo_data_ready_o ( fifo_tx_data_ready_o       ),
+        .fifo_data_ready_o ( s_fifo_tx_data_ready_o       ),
 
         .fifo_err_o        (                            ),
 
-        .cfg_en_i          ( cfg_master_en_i            ),
+        .cfg_en_i          ( s_i2s_mst_en            ),
         .cfg_2ch_i         ( cfg_master_i2s_2ch_i       ),
         .cfg_wlen_i        ( cfg_master_i2s_bits_word_i ),
         .cfg_wnum_i        ( cfg_master_i2s_words_i     ),

--- a/rtl/i2s_ws_gen.sv
+++ b/rtl/i2s_ws_gen.sv
@@ -28,11 +28,11 @@ module i2s_ws_gen
     output logic                    ws_o,
 
     input  logic              [4:0] cfg_data_size_i,
-    input  logic              [2:0] cfg_word_num_i
+    input  logic              [3:0] cfg_word_num_i
 );
 
     logic  [4:0] r_counter;
-    logic  [2:0] r_word_counter;
+    logic  [3:0] r_word_counter;
 
     //Generate the internal WS signal
     always_ff  @(posedge sck_i, negedge rstn_i)


### PR DESCRIPTION
In this version of the I2S I've implemented the time-division multiplexing using the DSP protocol.
In order to do this, I've modified some existing registers to extend the number of the sources up to 16 and I've also provided one more register for the DSP configuration.
Also, this IP has 2 I2S ports working with the DSP: 1 Master and 1 Slave.
Both are intended to send and receive data at the same time.

